### PR TITLE
Check more gently for presence of request.logger

### DIFF
--- a/lib/rack/wwwhisper.rb
+++ b/lib/rack/wwwhisper.rb
@@ -129,7 +129,7 @@ class WWWhisper
 
   private
   def debug(req, message)
-    req.logger.debug "wwwhisper #{message}" if req.respond_to?(:logger)
+    req.logger.debug "wwwhisper #{message}" if (req.respond_to?(:logger) && req.logger)
   end
 
   def parse_uri(uri)


### PR DESCRIPTION
This line crashed with a message like "no such method req.logger" in an old rails (2.3.5) project.  The new version should do what was intended in the original code.
