### PR TITLE
Lock net-http-persistent to < 3.0

### DIFF
--- a/rack-wwwhisper.gemspec
+++ b/rack-wwwhisper.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.license     = 'BSD'
   s.add_runtime_dependency 'rack', '>= 1.0'
   s.add_runtime_dependency 'addressable', '~> 2.0'
-  s.add_runtime_dependency 'net-http-persistent'
+  s.add_runtime_dependency 'net-http-persistent', '< 3.0'
   s.add_development_dependency 'rack-test'
   s.add_development_dependency 'webmock'
   s.add_development_dependency 'test-unit'


### PR DESCRIPTION
In `net-http-persistent` initialization of the Net::HTTP::Persistent
object has now moved to expecting keyword arguments instead of
positional arguments.

I considered updating the initialization for the new syntax expected by net-http-persistent but decided there's probably more testing that needs to be done in order to feel confident in allowing a major version bump on an important dependency and that this should at least be helpful for the interim.